### PR TITLE
Update highcharts-ng.js

### DIFF
--- a/src/highcharts-ng.js
+++ b/src/highcharts-ng.js
@@ -148,7 +148,7 @@ if (typeof module !== 'undefined' && typeof exports !== 'undefined' && module.ex
       var originalWidth = $element[0].clientWidth;
       var originalHeight = $element[0].clientHeight;
       $timeout(function () {
-        if ($element[0].clientWidth !== originalWidth || $element[0].clientHeight !== originalHeight) {
+        if ($element[0].clientWidth !== 0 && $element[0].clientHeight !== 0 && ($element[0].clientWidth !== originalWidth || $element[0].clientHeight !== originalHeight)) {
           ctrl.chart.reflow();
         }
       }, 0, false);


### PR DESCRIPTION
Fix to prevent redrawing when anchor element is hidden or has been removed. 